### PR TITLE
Updates to get Linux kernel information

### DIFF
--- a/usr/local/bin/use
+++ b/usr/local/bin/use
@@ -72,18 +72,15 @@ sed '2d' /bootloader
 echo "----------------------------------------------------"
 tput sgr0;echo "Installed Kernels";tput setaf 9
 echo "----------------------------------------------------"
-#ls /usr/lib/modules#
 i=0
 for kernel in /usr/lib/modules/*; do
-    i=$((i+1))
     kernel_version=$(find ${kernel} -iname "vmlinuz" | awk -F'/' '{print $5}')
-    echo "[$i] $kernel_version"
+    test ! -z "$kernel_version" && i=$((i+1)) && echo "[$i] $kernel_version"
 done
 echo "----------------------------------------------------"
 tput sgr0;echo "Active Kernel";tput setaf 9
 echo "----------------------------------------------------"
-#cat /proc/version
-kernel-install | awk '/Kernel Version:/' | sed 's/Kernel Version://' | xargs
+uname -rs
 echo "----------------------------------------------------"
 tput sgr0;echo "Kernel Parameters";tput setaf 9
 echo "----------------------------------------------------"

--- a/usr/local/bin/use
+++ b/usr/local/bin/use
@@ -70,13 +70,24 @@ tput sgr0;echo "Boot system";tput setaf 9
 echo "----------------------------------------------------"
 sed '2d' /bootloader
 echo "----------------------------------------------------"
-tput sgr0;echo "Kernels";tput setaf 9
+tput sgr0;echo "Installed Kernels";tput setaf 9
 echo "----------------------------------------------------"
-ls /usr/lib/modules
+#ls /usr/lib/modules#
+i=0
+for kernel in /usr/lib/modules/*; do
+    i=$((i+1))
+    kernel_version=$(find ${kernel} -iname "vmlinuz" | awk -F'/' '{print $5}')
+    echo "[$i] $kernel_version"
+done
 echo "----------------------------------------------------"
-tput sgr0;echo "Kernel in use";tput setaf 9
+tput sgr0;echo "Active Kernel";tput setaf 9
 echo "----------------------------------------------------"
-cat /proc/version
+#cat /proc/version
+kernel-install | awk '/Kernel Version:/' | sed 's/Kernel Version://' | xargs
+echo "----------------------------------------------------"
+tput sgr0;echo "Kernel Parameters";tput setaf 9
+echo "----------------------------------------------------"
+cat /proc/cmdline
 echo "----------------------------------------------------"
 tput sgr0
 # List of potential display managers

--- a/usr/local/bin/use
+++ b/usr/local/bin/use
@@ -74,8 +74,8 @@ tput sgr0;echo "Installed Kernels";tput setaf 9
 echo "----------------------------------------------------"
 i=0
 for kernel in /usr/lib/modules/*; do
-    kernel_version=$(find ${kernel} -iname "vmlinuz" | awk -F'/' '{print $5}')
-    test ! -z "$kernel_version" && i=$((i+1)) && echo "[$i] $kernel_version"
+    kernel_version=$(find ${kernel} -name "vmlinuz" | awk -F'/' '{print $5}')
+    test ! -z "$kernel_version" && test -s "$kernel/vmlinuz" && i=$((i+1)) && echo "[$i] $kernel_version"
 done
 echo "----------------------------------------------------"
 tput sgr0;echo "Active Kernel";tput setaf 9


### PR DESCRIPTION
Move away from listing /usr/lib/modules, since there is no guarantee that the kernel is installed that way.
Loop through /usr/lib/modules and test the size and existence of 'vmlinuz'.
Outputs:

```sh
Installed Kernels
----------------------------------------------------
[1] 6.9.8-1-cachyos
[2] 6.9.8-arch1-1
[3] 6.9.8-nitrous+
----------------------------------------------------
```

Additionally, made change to:

- Print Active kernel `uname -rs`

- Added print of `cat /proc/cmdline`